### PR TITLE
remove unused code with SyntaxErrors

### DIFF
--- a/src/invest_reports/jinja_report_generators/ndr_report_generator.py
+++ b/src/invest_reports/jinja_report_generators/ndr_report_generator.py
@@ -79,25 +79,3 @@ def report(file_registry, args_dict, model_spec, target_html_filepath):
         file_registry, args_dict, model_spec, target_html_filepath,
         raster_plot_configs)
 
-
-# @TODO: remove this block for InVEST Workbench integration
-if __name__ == '__main__':
-    from natcap.invest.ndr.ndr import MODEL_SPEC
-    import natcap.invest.datastack
-    handler = logging.StreamHandler(sys.stdout)
-    logging.basicConfig(level=logging.INFO, handlers=[handler])
-    logfile_path = '/Users/eadavis/invest-workspaces/ndr/InVEST-ndr-log-2025-12-01--15_34_31.txt'
-    _, ds_info = natcap.invest.datastack.get_datastack_info(logfile_path)
-    args_dict = MODEL_SPEC.preprocess_inputs(ds_info.args)
-    file_registry_path = os.path.join(
-        args_dict['workspace_dir'],
-        f'file_registry{args_dict['results_suffix']}.json')
-
-    with open(file_registry_path, 'r') as file:
-        file_registry = json.loads(file.read())
-
-    target_filepath = os.path.join(
-        args_dict['workspace_dir'],
-        f'{MODEL_SPEC.model_id.lower()}_report{args_dict['results_suffix']}.html')
-
-    report(file_registry, args_dict, MODEL_SPEC, target_filepath)

--- a/src/invest_reports/jinja_report_generators/sdr_report_generator.py
+++ b/src/invest_reports/jinja_report_generators/sdr_report_generator.py
@@ -64,26 +64,3 @@ def report(file_registry, args_dict, model_spec, target_html_filepath):
     sdr_ndr_report_generator.report(
         file_registry, args_dict, model_spec, target_html_filepath,
         raster_plot_configs)
-
-
-# @TODO: remove this block for InVEST Workbench integration
-if __name__ == '__main__':
-    from natcap.invest.sdr.sdr import MODEL_SPEC
-    import natcap.invest.datastack
-    handler = logging.StreamHandler(sys.stdout)
-    logging.basicConfig(level=logging.INFO, handlers=[handler])
-    logfile_path = '/Users/eadavis/invest-workspaces/sdr/InVEST-sdr-log-2025-10-29--15_26_12.txt'
-    _, ds_info = natcap.invest.datastack.get_datastack_info(logfile_path)
-    args_dict = MODEL_SPEC.preprocess_inputs(ds_info.args)
-    file_registry_path = os.path.join(
-        args_dict['workspace_dir'],
-        f'file_registry{args_dict['results_suffix']}.json')
-
-    with open(file_registry_path, 'r') as file:
-        file_registry = json.loads(file.read())
-
-    target_filepath = os.path.join(
-        args_dict['workspace_dir'],
-        f'{MODEL_SPEC.model_id.lower()}_report{args_dict['results_suffix']}.html')
-
-    report(file_registry, args_dict, MODEL_SPEC, target_filepath)


### PR DESCRIPTION
Hey @emilyanndavis I think it's time to remove these blocks because this error is raised on compilation, so that's failing the tests over here. https://github.com/natcap/invest/actions/runs/20070480740/job/57570909468?pr=2232

```
jinja_report_generators/sdr_report_generator.py", line 80
    f'file_registry{args_dict['results_suffix']}.json')
                               ^^^^^^^^^^^^^^
SyntaxError: f-string: unmatched '['
```

I agree this code is handy to keep around for personal testing, perhaps in a script that is not checked into the repo. That's what I have done for CV.