### PR TITLE
SDR/NDR utils tests

### DIFF
--- a/tests/test_sdr_ndr_utils.py
+++ b/tests/test_sdr_ndr_utils.py
@@ -1,0 +1,188 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import geopandas
+import lxml.html
+import shapely
+
+from invest_reports import sdr_ndr_utils
+
+
+MAIN_TABLE_COLS = ['ws_id', 'ws_name',
+                   'calculated_value_1', 'calculated_value_2']
+
+
+def _generate_mock_watershed_data(num_features):
+    ws_names = ['Willamette', 'Columbia', 'Snake', 'Salmon', 'Boise',
+                'Owyhee', 'Deschutes', 'Sacramento', 'American', 'Tuolomne',
+                'San Joaquin', 'Los Angeles', 'Santa Ana', 'Colorado', 'Green',
+                'Wind', 'Yellowstone', 'Missouri', 'Mississippi', 'Minnesota',
+                'Rock', 'Chicago', 'Detroit', 'Ohio', 'Cuyahoga',
+                'Allegheny', 'Youghiogheny', 'Genesee', 'Susquehanna', 'Hudson',
+                'Connecticut', 'Potomac', 'Patapsco', 'Patuxent', 'Shenandoah',
+                'Tennessee', 'Red', 'Arkansas', 'Platte']
+    # All polygons can be identical: their specifics don't matter to the tests.
+    polygon = shapely.Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0)))
+    polygons = geopandas.GeoSeries([polygon] * num_features)
+    columns = MAIN_TABLE_COLS
+    vector_data = [[i + 1, ws_names[i % len(ws_names)], i + 101, i + 201]
+                   for i in range(num_features)]
+    # The CRS is irrelevant, but specifying one prevents a user warning.
+    dataframe = geopandas.GeoDataFrame(
+        vector_data, columns=columns,
+        geometry=polygons, crs='EPSG:4326')
+    return (vector_data, dataframe)
+
+
+class SDRNDRUtilsTests(unittest.TestCase):
+    """Unit tests for SDR/NDR utils."""
+
+    def setUp(self):
+        """Initialize SDRNDRUtilsTests tests."""
+        self.workspace_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up remaining files."""
+        shutil.rmtree(self.workspace_dir)
+
+    def test_generate_results_table_single_feature(self):
+        """Return a single-row HTML table; do not return totals."""
+
+        num_features = 1
+
+        (vector_data, dataframe) = _generate_mock_watershed_data(num_features)
+        filepath = os.path.join(self.workspace_dir, 'vector.gpkg')
+        dataframe.to_file(filepath, driver='GPKG')
+        cols_to_sum = []
+
+        (main_table, totals_table) = (
+            sdr_ndr_utils.generate_results_table_from_vector(
+                filepath, cols_to_sum))
+        self.assertIsNotNone(main_table)
+
+        root = lxml.html.document_fromstring(main_table)
+
+        # Make sure table body has exactly 1 row.
+        table_body_rows = root.xpath('.//table/tbody/tr')
+        self.assertEqual(len(table_body_rows), num_features)
+
+        # Make sure table body has expected number of columns.
+        ws_1_row = table_body_rows[0]
+        ws_1_cells = ws_1_row.xpath('./td')
+        self.assertEqual(len(ws_1_cells), 4)
+
+        # Check values.
+        ws_1_data = vector_data[0]
+        for (i, val) in enumerate(ws_1_data, start=1):
+            ws_1_cell = ws_1_row.xpath(f'./td[{i}]')
+            self.assertEqual(str(val), ws_1_cell[0].text)
+
+        # Make sure table has class 'datatable' but not 'paginate'.
+        datatable_table = root.find_class('datatable')
+        self.assertEqual(len(datatable_table), 1)
+        paginated_table = root.find_class('paginate')
+        self.assertEqual(len(paginated_table), 0)
+
+        # Make sure totals_table is None.
+        self.assertIsNone(totals_table)
+
+    def test_generate_results_table_and_totals(self):
+        """Return main table and totals table when vector has > 1 feature."""
+
+        num_features = 2
+
+        (vector_data, dataframe) = _generate_mock_watershed_data(num_features)
+        filepath = os.path.join(self.workspace_dir, 'vector.gpkg')
+        dataframe.to_file(filepath, driver='GPKG')
+        cols_to_sum = ['calculated_value_1', 'calculated_value_2']
+
+        (main_table, totals_table) = (
+            sdr_ndr_utils.generate_results_table_from_vector(
+                filepath, cols_to_sum))
+        self.assertIsNotNone(main_table)
+
+        main_table_root = lxml.html.document_fromstring(main_table)
+
+        # Make sure main table body has exactly 2 rows.
+        table_body_rows = main_table_root.xpath('.//table/tbody/tr')
+        self.assertEqual(len(table_body_rows), num_features)
+
+        # Make sure main table body has expected number of columns.
+        ws_1_row = table_body_rows[0]
+        ws_1_cells = ws_1_row.xpath('./td')
+        self.assertEqual(len(ws_1_cells), 4)
+
+        # @TODO: get this working
+        # # Check main table column headings for accuracy.
+        # table_header_rows = main_table_root.xpath('.//table/thead/tr')
+        # table_header_row = table_header_rows[0]
+        # col_names = MAIN_TABLE_COLS
+        # for (i, col_name) in enumerate(col_names, start=1):
+        #     col_header = table_header_row.xpath(f'./th{i}')
+        #     self.assertEqual(col_name, col_header[0].text)
+
+        # @TODO: get this working
+        # # Check main table values.
+        # for (i, ws_data) in enumerate(vector_data):
+        #     html_table_row = table_body_rows[i]
+        #     for (j, val) in enumerate(ws_data, start=1):
+        #         table_cell = html_table_row.xpath(f'./td{j}')
+        #         self.assertEqual(str(val), table_cell[0].text)
+
+        # Make sure main table has class 'datatable' but not 'paginate'.
+        datatable_table = main_table_root.find_class('datatable')
+        self.assertEqual(len(datatable_table), 1)
+        paginated_table = main_table_root.find_class('paginate')
+        self.assertEqual(len(paginated_table), 0)
+
+        # Make sure totals table is not None.
+        self.assertIsNotNone(totals_table)
+
+        totals_table_root = lxml.html.document_fromstring(totals_table)
+
+        # Make sure totals table body has exactly 1 row.
+        table_body_rows = totals_table_root.xpath('.//table/tbody/tr')
+        self.assertEqual(len(table_body_rows), 1)
+
+        # Make sure totals table body has expected number of columns.
+        totals_row = table_body_rows[0]
+        totals_cells = totals_row.xpath('./td')
+        self.assertEqual(len(totals_cells), 2)
+
+        # @TODO: get this working
+        # # Check totals table column headings for accuracy.
+        # table_header_rows = totals_table_root.xpath('.//table/thead/tr')
+        # table_header_row = table_header_rows[0]
+        # for (i, col_name) in enumerate(cols_to_sum, start=1):
+        #     col_header = table_header_row.xpath(f'./td{i}')
+        #     self.assertEqual(col_name, col_header[0].text)
+
+        # Check totals table values.
+        # calculated_value_1 is ws_id + 100; calculated_value_2 is ws_id + 200.
+        totals = [101 + 102, 201 + 202]
+        for (i, val) in enumerate(totals, start=1):
+            totals_cell = totals_row.xpath(f'./td[{i}]')
+            self.assertEqual(str(val), totals_cell[0].text)
+
+    def test_generate_results_table_with_pagination_directive(self):
+        """Return table with paginate flag when there are a lot of features."""
+
+        num_features = 11
+
+        (vector_data, dataframe) = _generate_mock_watershed_data(num_features)
+        filepath = os.path.join(self.workspace_dir, 'vector.gpkg')
+        dataframe.to_file(filepath, driver='GPKG')
+        cols_to_sum = ['calculated_value_1', 'calculated_value_2']
+
+        (main_table, totals_table) = (
+            sdr_ndr_utils.generate_results_table_from_vector(
+                filepath, cols_to_sum))
+        self.assertIsNotNone(main_table)
+
+        # @TODO: check that num rows in tbody == num features in vector
+        # @TODO: make sure table has class 'datatable' AND has class 'paginate'
+
+        self.assertIsNotNone(totals_table)
+        # @TODO: check column headings and table content for accuracy

--- a/tests/test_sdr_ndr_utils.py
+++ b/tests/test_sdr_ndr_utils.py
@@ -8,6 +8,8 @@ import lxml.html
 import shapely
 
 from invest_reports import sdr_ndr_utils
+from natcap.invest import spec
+from natcap.invest.unit_registry import u
 
 
 MAIN_TABLE_COLS = ['ws_id', 'ws_name',
@@ -221,3 +223,42 @@ class SDRNDRUtilsTests(unittest.TestCase):
         for (i, val) in enumerate(totals, start=1):
             totals_cell = totals_row.xpath(f'./td[{i}]')
             self.assertEqual(str(val), totals_cell[0].text)
+
+    def test_generate_caption_from_raster_list(self):
+        raster_list = [('raster_1', 'input'), ('raster_2', 'output')]
+        args_dict = {'raster_1': 'path/to/raster_1.tif'}
+        file_registry = {'raster_2': 'path/to/raster_2.tif'}
+        model_spec = spec.ModelSpec(
+            model_id='',
+            model_title='',
+            userguide='',
+            module_name='',
+            input_field_order=[['raster_1']],
+            inputs=[
+                spec.SingleBandRasterInput(
+                    id='raster_1',
+                    units=u.none,
+                    about='Map of land use/land cover codes.',
+                ),
+            ],
+            outputs=[
+                spec.SingleBandRasterOutput(
+                    id='raster_2',
+                    path='path/to/raster_2.tif',
+                    units=u.metric_ton / u.hectare,
+                    about=('The total amount of sediment exported from each '
+                           'pixel that reaches the stream.'),
+                )
+            ],
+        )
+
+        expected_caption = [
+            'raster_1.tif:Map of land use/land cover codes.',
+            ('raster_2.tif:The total amount of sediment exported from each '
+             'pixel that reaches the stream.')
+        ]
+
+        generated_caption = sdr_ndr_utils.generate_caption_from_raster_list(
+            raster_list, args_dict, file_registry, model_spec)
+
+        self.assertEqual(generated_caption, expected_caption)

--- a/tests/test_sdr_ndr_utils.py
+++ b/tests/test_sdr_ndr_utils.py
@@ -75,6 +75,7 @@ class SDRNDRUtilsTests(unittest.TestCase):
 
         # Check values.
         ws_1_data = vector_data[0]
+        # xpath positions are 1-indexed.
         for (i, val) in enumerate(ws_1_data, start=1):
             ws_1_cell = ws_1_row.xpath(f'./td[{i}]')
             self.assertEqual(str(val), ws_1_cell[0].text)
@@ -114,22 +115,22 @@ class SDRNDRUtilsTests(unittest.TestCase):
         ws_1_cells = ws_1_row.xpath('./td')
         self.assertEqual(len(ws_1_cells), 4)
 
-        # @TODO: get this working
-        # # Check main table column headings for accuracy.
-        # table_header_rows = main_table_root.xpath('.//table/thead/tr')
-        # table_header_row = table_header_rows[0]
-        # col_names = MAIN_TABLE_COLS
-        # for (i, col_name) in enumerate(col_names, start=1):
-        #     col_header = table_header_row.xpath(f'./th{i}')
-        #     self.assertEqual(col_name, col_header[0].text)
+        # Check main table column headings for accuracy.
+        table_header_rows = main_table_root.xpath('.//table/thead/tr')
+        table_header_row = table_header_rows[0]
+        col_names = MAIN_TABLE_COLS
+        # xpath positions are 1-indexed.
+        for (i, col_name) in enumerate(col_names, start=1):
+            col_header = table_header_row.xpath(f'./th[{i}]')
+            self.assertEqual(col_name, col_header[0].text)
 
-        # @TODO: get this working
-        # # Check main table values.
-        # for (i, ws_data) in enumerate(vector_data):
-        #     html_table_row = table_body_rows[i]
-        #     for (j, val) in enumerate(ws_data, start=1):
-        #         table_cell = html_table_row.xpath(f'./td{j}')
-        #         self.assertEqual(str(val), table_cell[0].text)
+        # Check main table values.
+        for (i, ws_data) in enumerate(vector_data):
+            html_table_row = table_body_rows[i]
+            # xpath positions are 1-indexed.
+            for (j, val) in enumerate(ws_data, start=1):
+                table_cell = html_table_row.xpath(f'./td[{j}]')
+                self.assertEqual(str(val), table_cell[0].text)
 
         # Make sure main table has class 'datatable' but not 'paginate'.
         datatable_table = main_table_root.find_class('datatable')
@@ -151,17 +152,18 @@ class SDRNDRUtilsTests(unittest.TestCase):
         totals_cells = totals_row.xpath('./td')
         self.assertEqual(len(totals_cells), 2)
 
-        # @TODO: get this working
-        # # Check totals table column headings for accuracy.
-        # table_header_rows = totals_table_root.xpath('.//table/thead/tr')
-        # table_header_row = table_header_rows[0]
-        # for (i, col_name) in enumerate(cols_to_sum, start=1):
-        #     col_header = table_header_row.xpath(f'./td{i}')
-        #     self.assertEqual(col_name, col_header[0].text)
+        # Check totals table column headings for accuracy.
+        table_header_rows = totals_table_root.xpath('.//table/thead/tr')
+        table_header_row = table_header_rows[0]
+        # xpath positions are 1-indexed. Skip first (empty) th and start at 2.
+        for (i, col_name) in enumerate(cols_to_sum, start=2):
+            col_header = table_header_row.xpath(f'./th[{i}]')
+            self.assertEqual(col_name, col_header[0].text)
 
         # Check totals table values.
         # calculated_value_1 is ws_id + 100; calculated_value_2 is ws_id + 200.
         totals = [101 + 102, 201 + 202]
+        # xpath positions are 1-indexed.
         for (i, val) in enumerate(totals, start=1):
             totals_cell = totals_row.xpath(f'./td[{i}]')
             self.assertEqual(str(val), totals_cell[0].text)


### PR DESCRIPTION
Adds tests for the increasingly inaccurately named SDR/NDR utils. Specifically covers `generate_results_table_from_vector` and `generate_caption_from_raster_list` functions.